### PR TITLE
Optional 'until' date time

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,14 +14,15 @@ Oprah: +4893 -5202
 
 - Clone the repo
 - `$ cd cloc-author-date`
-- `$ ./cloc-author-date '<<SINCE>>' '<<AUTHORS>>`
-  - `<<SINCE>>` is a [unix timestamp](https://github.com/git/git/blob/master/Documentation/date-formats.txt). Examples:
+- `$ ./cloc-author-date '<<SINCE>>' '<<AUTHORS>>' '<<OPTIONAL_UNTIL>>'`
+  - `'<<SINCE>>'` is a [unix timestamp](https://github.com/git/git/blob/master/Documentation/date-formats.txt). Examples:
     - '1.year'
     - '1.month'
     - '1.day'
     - 'jan 01 1970'
-  - `<<AUTHORS>>` is a space separated list of git authors
+  - `'<<AUTHORS>>'` is a space separated list of git authors
     - git authors can be found by running `git shortlog -sne` in a git initialized repo.
+  - `'<<OPTIONAL_UNTIL>>'` is an optional param that takes in a unix timestamp. If nothing is provided, it defaults to the current date and time. Refer to the examples from `'<<SINCE>>'` for a unix time stamp.
 - Generate a `repos.txt` file at the root of the cloc-author-date directory (This file is git ignored)
   - Fill the file with SSH or HTTPS clone links separated by new lines. Example:
 

--- a/cloc-author-date
+++ b/cloc-author-date
@@ -1,15 +1,15 @@
  #!/bin/bash
  
 git_author_stats() {
-  git -C $1 log --author="$2" --since=$3 --numstat --pretty="%ae %H" \
+  git -C $1 log --author="$2" --since=$3  --until=$4 --numstat --pretty="%ae %H" \
     | grep -v -E '.*\.(svg)$' \
     | sed 's/@.*//g' \
     | awk '{ if (NF == 1){ name = $1}; if(NF == 3) {plus[name] += $1; minus[name] += $2}} END { for (name in plus) {print name": "plus[name]" "minus[name]}}' \
     | sort -k2 -gr
 }
 
-if [ $# -ne 2 ]; then
-  echo "Invalid arguments. Usage: ./cloc-author-date '<since-date>' 'author(s)'"
+if [ $# -lt 2 ]; then
+  echo "Invalid arguments. Usage: ./cloc-author-date '<since-date>' 'author(s)' '<optional-until-date>'"
   exit 1
 fi
 
@@ -20,12 +20,14 @@ fi
 
 SINCE=$1
 USERS=$2
+UNTIL=${3:-$(date)}
 REPOS=$(cat "repos.txt")
 
 rm -rf .cloc-tmp
 rm -rf reports
 mkdir reports
 
+echo "Counting lines of code between $SINCE -> $UNTIL"
 for REPO in $REPOS
 do
     echo "Pull down $REPO repo 📁"
@@ -34,7 +36,7 @@ do
     for USER in $USERS
     do
         echo "Generating report for $USER 📄"
-        git_author_stats $DIR $USER $SINCE >> ./reports/$USER.txt
+        git_author_stats $DIR $USER $SINCE $UNTIL >> ./reports/$USER.txt
     done
 done
 


### PR DESCRIPTION
This feature allows a user to optionally add a third parameter to the
script which captures an "until" date and passes it to the git cli. This
will allow users to run reports for quarters or time lines in the past.
If the parameter is left empty it will default to the current date time.